### PR TITLE
Add username in Message serializer.

### DIFF
--- a/chatrooms/serializers.py
+++ b/chatrooms/serializers.py
@@ -11,10 +11,14 @@ class ChatRoomSerializer(serializers.ModelSerializer):
         fields = ['id','name']
 
 class MessageSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(source='user.username', read_only=True)
+    user = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), write_only=True)
+   
     class Meta:
         model = Message
-        fields = ['id','chat_romm','user','text']
-
+        fields = ['id','chat_romm','username','text','user']
+    
+    
 class RegisterSerializer(serializers.ModelSerializer):
     email = serializers.EmailField(
             required=True,

--- a/chatrooms/serializers.py
+++ b/chatrooms/serializers.py
@@ -13,10 +13,10 @@ class ChatRoomSerializer(serializers.ModelSerializer):
 class MessageSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username', read_only=True)
     user = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), write_only=True)
-   
+    chatroom_name = serializers.CharField(source='chat_romm.name', read_only=True)
     class Meta:
         model = Message
-        fields = ['id','chat_romm','username','text','user']
+        fields = ['id','chat_romm','username','text','user','chatroom_name']
     
     
 class RegisterSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
In MessageSerilaizer, I added the usernames of the users so that it would be easy for the users to see the comments by the users instead of their primary id.